### PR TITLE
fix [hidden] attribute override + preserve partial pagination results

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -37,6 +37,12 @@ html[data-theme="light"] {
 
 * { box-sizing: border-box; }
 
+/* The HTML `hidden` attribute has the same specificity as a class selector
+ * (0,0,1,0). Several rules below set `display: flex` on classes that may
+ * also carry `hidden`, which would silently win on source order. Force the
+ * attribute to take precedence. */
+[hidden] { display: none !important; }
+
 html, body {
     margin: 0;
     padding: 0;

--- a/js/main.js
+++ b/js/main.js
@@ -143,9 +143,10 @@ function createPlayer() {
             },
             onStateChange: (e) => {
                 if (e.data === YT.PlayerState.ENDED && state.currentChannel) {
+                    startRun();
                     pickAndPlayRandom(state.currentChannel).catch(err => {
                         console.error(err);
-                        flashStatus(err.message || 'Failed to play next', 'error', 4000);
+                        showError(err, 'Failed to play next');
                     });
                 }
             },

--- a/js/resolve.js
+++ b/js/resolve.js
@@ -165,17 +165,26 @@ export async function loadChannelVideos(ucid, { minVideos = 200, hardMaxPages = 
             const seen = new Set();
             let cont = null;
             for (let page = 0; page < hardMaxPages; page++) {
-                const { videos, continuation } = await b.call(ucid, cont);
-                if (!videos || videos.length === 0) break;
-                for (const v of videos) {
-                    if (v.videoId && !seen.has(v.videoId)) {
-                        seen.add(v.videoId);
-                        all.push(v);
+                try {
+                    const { videos, continuation } = await b.call(ucid, cont);
+                    if (!videos || videos.length === 0) break;
+                    for (const v of videos) {
+                        if (v.videoId && !seen.has(v.videoId)) {
+                            seen.add(v.videoId);
+                            all.push(v);
+                        }
                     }
+                    if (all.length >= minVideos) break;
+                    if (!continuation) break;
+                    cont = continuation;
+                } catch (pageErr) {
+                    // Pagination broke (e.g. Piped /nextpage/channel often
+                    // fails). If we already have some videos, keep them
+                    // instead of failing over to a different backend.
+                    if (all.length === 0) throw pageErr;
+                    console.warn(`[ytrandi] ${b.name}.channelVideos pagination stopped:`, pageErr.message);
+                    break;
                 }
-                if (all.length >= minVideos) break;
-                if (!continuation) break;
-                cont = continuation;
             }
             if (all.length > 0) return { videos: all, backend: b.name };
             lastErr = new Error('empty');


### PR DESCRIPTION
## Summary

Two more fixes that didn't make it into PR #4 because they were committed after that merge.

**1. `[hidden]` attribute being overridden by class selectors** (the actual reason the "All public APIs are unreachable" banner appeared on a freshly loaded page with zero network requests).

`.key-banner { display: flex }` and `.status-bar { display: flex }` have the same CSS specificity (0,0,1,0) as the UA `[hidden] { display: none }` rule but appear later in the cascade, so they silently won. Both elements were rendered regardless of the `hidden` attribute.

Fix: add a global `[hidden] { display: none !important }` so the HTML attribute is authoritative.

**2. Pagination preserving partial results.**

`loadChannelVideos` would discard a successful first page and fail over to the next backend if a later page threw — Piped's `/nextpage/channel/...` is flaky on many instances. That caused the false "both backends failed" path even when the user actually had a working video list. Plus `onStateChange` ENDED auto-next now resets the per-run error log too.

## Test plan

- [ ] Open the page fresh (hard-refresh) → confirm no banner is visible.
- [ ] Confirm status bar is hidden until an actual status message appears.
- [ ] Search a channel that triggers Piped pagination (e.g. a channel with many videos) → confirm video plays without falling through to Invidious or showing the banner.
- [ ] Let a video auto-end → next random plays without error log carry-over.

https://claude.ai/code/session_01NdVdFqTGPGRTX4ra2VzDJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdVdFqTGPGRTX4ra2VzDJA)_